### PR TITLE
Update documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,7 @@ a HAProxy TCP health check:
     backend plone03
         # ...
         option tcp-check
+        tcp-check connect
         tcp-check send health_check\r\n
         tcp-check expect string OK
 


### PR DESCRIPTION
- Add section on switching to `ftw.monitor`
- Add the required `tcp-check connect` to HAProxy example
