### PR TITLE
Add `perf_metrics` command to get various performance related metrics.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,9 +140,9 @@ If this behavior is not desired, automatic warmup can be disabled by setting
 the ``FTW_MONITOR_AUTOWARMUP`` environment variable to ``0`` before starting
 the instance(s):
 
-```bash
-export FTW_MONITOR_AUTOWARMUP=0
-```
+.. code:: bash
+
+    export FTW_MONITOR_AUTOWARMUP=0
 
 
 HAProxy example

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add `perf_metrics` command to get various performance related metrics.
+  [lgraf]
 
 
 1.0.0 (2019-11-18)

--- a/ftw/monitor/configure.zcml
+++ b/ftw/monitor/configure.zcml
@@ -23,6 +23,12 @@
       />
 
   <utility
+      component=".perf_metrics.perf_metrics"
+      provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
+      name="perf_metrics"
+      />
+
+  <utility
       component=".warmup.warmup_state"
       provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
       name="warmup_state"

--- a/ftw/monitor/perf_metrics.py
+++ b/ftw/monitor/perf_metrics.py
@@ -1,0 +1,111 @@
+from ftw.monitor.server import get_uptime
+from time import time
+from ZODB.interfaces import IDatabase
+from zope.component import getUtility
+from Zope2 import app as App  # noqa
+import json
+import psutil
+import Zope2
+
+
+def perf_metrics(connection, database='-', sampling_interval=300):
+    r"""Get performance related metrics.
+
+    Usage: Send the message 'perf_metrics\r\n' to the zc.monitor TCP port.
+
+    The plugin will then respond with a JSON encoded dictionary containing
+    several performance related metrics.
+
+    You can pass a database name, where "-" is an alias for the main database.
+
+    By default, the statistics are for a sampling interval of 5
+    minutes.  You can request another sampling interval, up to an
+    hour, by passing a sampling interval in seconds after the database name.
+    The sampling interval applies to statistics tracked by the ZODB
+    ActivityMonitor.
+    """
+    app = App()
+
+    # Make sure we have a connected storage available
+    try:
+        dbchooser = app.Control_Panel.Database
+        for dbname in dbchooser.getDatabaseNames():
+            storage = dbchooser[dbname]._getDB()._storage
+            is_connected = getattr(storage, 'is_connected', None)
+            if is_connected is not None and not is_connected():
+                msg = {'error': 'Database %r disconnected.' % dbname}
+                connection.write('%s\n' % json.dumps(msg))
+                return
+
+        # Get DB. These will be registered during startup in f.m.server
+        if database == '-':
+            database = 'main'
+        db = getUtility(IDatabase, database)
+
+        metrics = collect_performance_metrics(db, sampling_interval)
+        connection.write('%s\n' % json.dumps(metrics))
+
+    finally:
+        app._p_jar.close()
+
+
+def collect_performance_metrics(db, sampling_interval):
+    instance_stats = get_instance_stats()
+    cache_stats = get_cache_stats(db)
+    db_stats = get_db_stats(db, sampling_interval)
+    memory_stats = get_memory_stats()
+    metrics = {
+        'instance': instance_stats,
+        'cache': cache_stats,
+        'db': db_stats,
+        'memory': memory_stats,
+    }
+    return metrics
+
+
+def get_instance_stats():
+    return {'uptime': int(get_uptime())}
+
+
+def get_memory_stats():
+    meminfo = psutil.Process().memory_full_info()
+    pss = getattr(meminfo, 'pss', -1)  # pss is Linux only
+    return {'rss': meminfo.rss, 'uss': meminfo.uss, 'pss': pss}
+
+
+def get_cache_stats(db):
+    max_size = db.getCacheSize()
+    ngsize = size = 0
+    for detail in db.cacheDetailSize():
+        ngsize += detail['ngsize']
+        size += detail['size']
+
+    return {'size': size, 'ngsize': ngsize, 'max_size': max_size}
+
+
+def get_db_stats(db, sampling_interval):
+    conflicts = Zope2.zpublisher_exception_hook.conflict_errors
+    unresolved_conflicts = Zope2.zpublisher_exception_hook.unresolved_conflict_errors
+
+    am = db.getActivityMonitor()
+    if am is None:
+        activity = -1, -1, -1
+    else:
+        now = time()
+        start = now - int(sampling_interval)
+        analysis = am.getActivityAnalysis(start, now, 1)[0]
+        activity = (analysis['loads'],
+                    analysis['stores'],
+                    analysis['connections'],
+                    )
+
+    db_stats = {
+        'loads': activity[0],
+        'stores': activity[1],
+        'connections': activity[2],
+        'conflicts': conflicts,
+        'unresolved_conflicts': unresolved_conflicts,
+        'total_objs': db.objectCount(),
+        'size_in_bytes': db.getSize(),
+    }
+    return db_stats

--- a/ftw/monitor/tests/test_perf_metrics.py
+++ b/ftw/monitor/tests/test_perf_metrics.py
@@ -1,0 +1,86 @@
+from ftw.monitor import server
+from ftw.monitor.server import get_uptime
+from ftw.monitor.testing import MONITOR_INTEGRATION_TESTING
+from ftw.monitor.testing import MonitorTestCase
+import json
+import time
+
+
+TEST_ZODB_NAME = 'unnamed'
+
+
+class TestPerformanceMetricsPlugin(MonitorTestCase):
+
+    layer = MONITOR_INTEGRATION_TESTING
+
+    def request_perf_metrics(self):
+        cmd = 'perf_metrics %s\r\n' % TEST_ZODB_NAME
+        reply = self.send('127.0.0.1', self.monitor_port, cmd)
+        return json.loads(reply)
+
+    def test_monitor_server_responds_to_perf_metrics(self):
+        perf_metrics = self.request_perf_metrics()
+
+        self.assertItemsEqual(
+            ['instance', 'cache', 'db', 'memory'],
+            perf_metrics.keys())
+
+    def test_perf_metrics_contains_instance_metrics(self):
+        # Temporarily monkey patch startup time
+        fake_start_time = time.time() - 35
+        previous_startup_time = server.startup_time
+        server.startup_time = fake_start_time
+
+        instance_metrics = self.request_perf_metrics()['instance']
+        expected_uptime = get_uptime()
+
+        # Revert monkey patch
+        server.startup_time = previous_startup_time
+
+        actual_uptime = instance_metrics['uptime']
+        self.assertIsInstance(actual_uptime, int)
+        self.assertAlmostEqual(expected_uptime, actual_uptime, delta=2)
+
+    def test_perf_metrics_contains_cache_metrics(self):
+        cache_metrics = self.request_perf_metrics()['cache']
+
+        self.assertIsInstance(cache_metrics, dict)
+        self.assertItemsEqual(
+            ['size', 'ngsize', 'max_size'],
+            cache_metrics.keys())
+
+        for value in cache_metrics.values():
+            self.assertIsInstance(value, int)
+
+        db = self.portal._p_jar.db()
+        self.assertEqual(cache_metrics['max_size'], db.getCacheSize())
+
+    def test_perf_metrics_contains_db_metrics(self):
+        db_metrics = self.request_perf_metrics()['db']
+        self.assertIsInstance(db_metrics, dict)
+        self.assertItemsEqual([
+            'loads',
+            'stores',
+            'connections',
+            'conflicts',
+            'unresolved_conflicts',
+            'total_objs',
+            'size_in_bytes'],
+            db_metrics.keys())
+
+        for value in db_metrics.values():
+            self.assertIsInstance(value, int)
+
+        db = self.portal._p_jar.db()
+        self.assertEqual(db_metrics['total_objs'], db.objectCount())
+        self.assertEqual(db_metrics['size_in_bytes'], db.getSize())
+
+    def test_perf_metrics_contains_memory_metrics(self):
+        memory_metrics = self.request_perf_metrics()['memory']
+        self.assertIsInstance(memory_metrics, dict)
+        self.assertItemsEqual(
+            ['rss', 'uss', 'pss'],
+            memory_metrics.keys())
+
+        for value in memory_metrics.values():
+            self.assertIsInstance(value, int)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0.1.dev0'
+version = '1.1.0.dev0'
 
 tests_require = [
     'ftw.testing',
@@ -48,6 +48,7 @@ setup(
         'Plone',
         'setuptools',
         'plone.api',
+        'psutil',
         'requests',
         'zc.monitor',
         'zc.z3monitor',


### PR DESCRIPTION
This introduces a new command / plugin `perf_metrics` that allows to fetch various performance related metrics from an instance.

Syntax: ``perf_metrics [dbname] [sampling-interval]``

Example Output:

```json
    {
        "instance": {
            "uptime": 39
        },
        "cache": {
            "size": 3212,
            "ngsize": 1438,
            "max_size": 30000
        },
        "db": {
            "loads": 1114,
            "stores": 28,
            "connections": 459,
            "conflicts": 7,
            "unresolved_conflicts": 3,
            "total_objs": 13336,
            "size_in_bytes": 5796849
        },
        "memory": {
            "rss": 312422400,
            "uss": 298905600,
            "pss": 310822823
        }
    }

```

Tested with:
- ZEO
- RelStorage _(superficially, by testing the different API methods that are being used, and checking their results)_.
  - DB `size_in_bytes` reports an [approximation with PostgreSQL](https://github.com/zodb/relstorage/blob/1.6/relstorage/adapters/stats.py#L27-L32), `0` with [Oracle](https://github.com/zodb/relstorage/blob/1.6/relstorage/adapters/stats.py#L89-L92).
  - `total_objs` reports `0` for both [PostgreSQL](https://github.com/zodb/relstorage/blob/1.6/relstorage/adapters/stats.py#L22-L25) and [Oracle](https://github.com/zodb/relstorage/blob/1.6/relstorage/adapters/stats.py#L64-L69).
  - That's for RelStorage 1.6.3. It looks like a [newer version](https://github.com/zodb/relstorage/blob/master/src/relstorage/adapters/stats.py) of RelStorage might eventually provide these stats.

Response time with 1000 repeated invocations: `~30ms`

Part of:
Jira: https://4teamwork.atlassian.net/browse/GEVER-152