### PR TITLE
Add script to dump perf_metrics for all instances in InfluxDB format.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,7 @@ The command will return the metrics as a JSON encoded string
 - ``uss`` - USS (`Unique Set Size`_) in bytes
 - ``pss`` - PSS (Proportional Set Size) in bytes (Linux only, ``-1`` on other platforms)
 
+For easy ingestion into InfluxDB via Telegraf, performance metrics for all reachable instances can be dumped using the ``bin/dump-perf-metrics`` script. This script will collect metrics from all instances, and dump them in InfluxDB Line Protocol format.
 
 HAProxy example
 ---------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.1.1 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add script to dump perf_metrics for all instances in InfluxDB format.
+  [lgraf]
 
 
 1.1.0 (2020-04-30)

--- a/ftw/monitor/command.py
+++ b/ftw/monitor/command.py
@@ -1,3 +1,5 @@
+from ftw.monitor.dump_metrics import dump_all_perf_metrics
+from ftw.monitor.dump_metrics import get_deployment_dir
 from ftw.monitor.server import determine_monitor_port
 from ftw.monitor.utils import netcat
 
@@ -14,5 +16,12 @@ def monitor(zope2Cmd, *args):
         content = 'help'
     else:
         content = ' '.join(args)
-    reply = netcat('127.0.0.1', int(monitor_port), '%s\n' % content)
-    print reply
+    netcat('127.0.0.1', int(monitor_port), '%s\n' % content)
+
+
+def dump_perf_metrics():
+    """Collect and dump performance metrics for all instances in
+    InfluxDB line protocol format.
+    """
+    deployment_dir = get_deployment_dir()
+    print dump_all_perf_metrics(deployment_dir)

--- a/ftw/monitor/command.py
+++ b/ftw/monitor/command.py
@@ -1,17 +1,5 @@
 from ftw.monitor.server import determine_monitor_port
-import socket
-
-
-def netcat(hostname, port, content):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((hostname, port))
-    s.sendall(content)
-    while 1:
-        data = s.recv(1024)
-        if data == "":
-            break
-        print data.strip()
-    s.close()
+from ftw.monitor.utils import netcat
 
 
 def monitor(zope2Cmd, *args):
@@ -26,4 +14,5 @@ def monitor(zope2Cmd, *args):
         content = 'help'
     else:
         content = ' '.join(args)
-    netcat('127.0.0.1', int(monitor_port), '%s\n' % content)
+    reply = netcat('127.0.0.1', int(monitor_port), '%s\n' % content)
+    print reply

--- a/ftw/monitor/dump_metrics.py
+++ b/ftw/monitor/dump_metrics.py
@@ -1,0 +1,164 @@
+from fnmatch import fnmatch
+from ftw.monitor.utils import netcat
+from os.path import basename
+from os.path import join as pjoin
+import ConfigParser
+import json
+import logging
+import os
+import socket
+import sys
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig()
+
+
+def dump_all_perf_metrics(deployment_dir):
+    """Retrieves perf_metrics from all running instances and dumps them in
+    InfluxDB line protocol format.
+    """
+    instances = find_instances(deployment_dir)
+    deployment_name = basename(deployment_dir.rstrip(os.path.sep))
+    metrics = retrieve_all_perf_metrics(instances)
+    influx_lines = to_influxdb_line_protocol(metrics, deployment_name)
+    return influx_lines
+
+
+def find_instances(deployment_dir):
+    """Get a list of Zope instances based on filenames in bin/ directory,
+    and annotate them with their ports.
+    """
+    base_port = get_base_port(deployment_dir)
+
+    instances = []
+    instance_names = sorted(filter(
+        lambda n: fnmatch(n, 'instance?'),
+        os.listdir(pjoin(deployment_dir, 'bin'))))
+
+    for instance_name in instance_names:
+        instance_num = int(instance_name[-1])
+        instances.append({
+            'name': instance_name,
+            'number': instance_num,
+            'port': base_port + instance_num
+        })
+    return instances
+
+
+def get_deployment_dir():
+    """Locate the base directory of the deployment.
+
+    This relies on the fact that this code is invoked via a console_script
+    entry point, and the CWD plus the command line together consitute the
+    full, absolute path to the script.
+
+    The same strategy can't be used in other situations, like zopectl
+    commands. That's why this helper function currently lives in this module,
+    it's not intended to be reused without modification.
+    """
+    scriptname = 'bin/dump-perf-metrics'
+    script_location = pjoin(os.getcwd(), sys.argv[0])
+    assert script_location.endswith(scriptname)
+    deployment_dir, _ = script_location.split(scriptname)
+    return deployment_dir
+
+
+def get_supervisor_conf(deployment_dir):
+    """Return the parsed supervisord.conf
+    """
+    conf_path = pjoin(deployment_dir, 'parts', 'supervisor', 'supervisord.conf')
+    config = ConfigParser.RawConfigParser()
+    config.readfp(open(conf_path, 'rb'))
+    return config
+
+
+def get_supervisor_port(deployment_dir):
+    """Determine the supervisor deamon port for a deployment.
+    """
+    supervisor_conf = get_supervisor_conf(deployment_dir)
+    bind_addr = supervisor_conf.get('inet_http_server', 'port')
+    supervisor_port = int(bind_addr.split(':')[-1])
+    return supervisor_port
+
+
+def get_base_port(deployment_dir):
+    """Determine the base port for a deployment.
+    """
+    supervisor_port = get_supervisor_port(deployment_dir)
+    base_port = supervisor_port - 99
+    return base_port
+
+
+def fetch_perf_metrics(monitor_port, command='perf_metrics'):
+    """Given a single monitor port, fetch perf_metrics from it and parse
+    them as JSON.
+
+    Socket errors like connection refused or timeouts are logged on stderr,
+    but otherwise are handled defensively.
+    """
+    try:
+        host = '127.0.0.1'
+        reply = netcat(host, monitor_port, '%s\r\n' % command, timeout=1)
+
+    except socket.error as exc:
+        logger.warn('%s:%s - %s' % (host, monitor_port, exc))
+        return {}
+
+    return json.loads(reply)
+
+
+def to_influxdb_line_protocol(collected_metrics, deployment_name):
+    """
+    Convert a dict of metrics for multiple process to InfluxDB line protocol.
+
+    Format:
+    weather,location=us-midwest temperature=82 1465839830100400200
+      |    -------------------- --------------  |
+      |             |             |             |
+      |             |             |             |
+    +-----------+--------+-+---------+-+---------+
+    |measurement|,tag_set| |field_set| |timestamp|
+    +-----------+--------+-+---------+-+---------+
+    """
+    lines = []
+
+    measurement = 'deployments'
+
+    for process_name, metrics in sorted(collected_metrics.items()):
+        tags = {
+            'deployment': deployment_name,
+            'process': process_name,
+        }
+        tag_set = ','.join(
+            ['%s=%s' % (tag, val) for tag, val in sorted(tags.items())])
+
+        flattened_fields = []
+        for category, fields in sorted(metrics.items()):
+            for fn, value in sorted(fields.items()):
+                fqfn = '%s.%s' % (category, fn)
+                flattened_fields.append('%s=%s' % (fqfn, value))
+
+        field_set = ','.join(flattened_fields)
+
+        line = '%s,%s %s\n' % (measurement, tag_set, field_set)
+        lines.append(line)
+
+    return ''.join(lines)
+
+
+def retrieve_all_perf_metrics(instances, command='perf_metrics'):
+    """Fetch perf_metrics from all reachable instances.
+    """
+    collected_metrics = {}
+
+    for instance in instances:
+        if instance['name'] == 'instance0':
+            continue
+
+        monitor_port = instance['port'] + 80
+        perf_metrics = fetch_perf_metrics(monitor_port, command=command)
+        if perf_metrics:
+            collected_metrics[instance['name']] = perf_metrics
+
+    return collected_metrics

--- a/ftw/monitor/tests/test_dump_metrics.py
+++ b/ftw/monitor/tests/test_dump_metrics.py
@@ -1,0 +1,151 @@
+from ftw.monitor.dump_metrics import fetch_perf_metrics
+from ftw.monitor.dump_metrics import find_instances
+from ftw.monitor.dump_metrics import get_base_port
+from ftw.monitor.dump_metrics import get_supervisor_conf
+from ftw.monitor.dump_metrics import get_supervisor_port
+from ftw.monitor.dump_metrics import retrieve_all_perf_metrics
+from ftw.monitor.dump_metrics import to_influxdb_line_protocol
+from ftw.monitor.testing import MONITOR_INTEGRATION_TESTING
+from ftw.monitor.testing import MonitorTestCase
+from ftw.testing.layer import TEMP_DIRECTORY
+from os.path import join as pjoin
+from unittest import TestCase
+import os
+import textwrap
+
+
+TEST_ZODB_NAME = 'unnamed'
+
+
+def parse_influx_line(line):
+    """Parse a single InfluxDB line protocol line.
+
+    Format:
+    measurement,tag1=val1,tag2=val2 fld1=val1,fld2=val2
+    """
+    preamble, field_set = line.split(' ')
+    measurement, tag_set = preamble.split(',', 1)
+
+    tags = dict([pair.split('=') for pair in tag_set.split(',')])
+    fields = dict([pair.split('=') for pair in field_set.split(',')])
+
+    return {
+        'measurement': measurement,
+        'tags': tags,
+        'fields': fields,
+    }
+
+
+class TestDumpMetrics(MonitorTestCase):
+
+    layer = MONITOR_INTEGRATION_TESTING
+
+    def test_retrieve_all_perf_metrics(self):
+        pseudo_instance_port = self.monitor_port - 80
+
+        result = retrieve_all_perf_metrics([
+            {'name': 'instance1', 'port': pseudo_instance_port},
+            {'name': 'instance2', 'port': pseudo_instance_port},
+
+        ], command='perf_metrics %s' % TEST_ZODB_NAME)
+
+        self.assertItemsEqual(['instance1', 'instance2'], result.keys())
+
+        self.assertItemsEqual(
+            [u'instance', u'cache', u'db', u'memory'],
+            result['instance1'].keys())
+
+    def test_fetch_perf_metrics(self):
+        metrics = fetch_perf_metrics(
+            self.monitor_port, command='perf_metrics %s' % TEST_ZODB_NAME)
+
+        self.assertItemsEqual(
+            [u'instance', u'cache', u'db', u'memory'], metrics.keys())
+
+
+class TestDumpMetricsUnit(TestCase):
+
+    layer = TEMP_DIRECTORY
+
+    def _create_fake_deployment_directory(self):
+        deployment_dir = self.layer['temp_directory']
+        bin_dir = pjoin(deployment_dir, 'bin')
+        os.makedirs(bin_dir)
+
+        for instance_no in range(0, 5):
+            instance_name = 'instance%s' % instance_no
+            path = pjoin(bin_dir, instance_name)
+            path.touch()
+
+        supervisor_dir = pjoin(deployment_dir, 'parts', 'supervisor')
+        os.makedirs(supervisor_dir)
+
+        supervisord_conf_path = pjoin(supervisor_dir, 'supervisord.conf')
+        with open(supervisord_conf_path, 'w') as sv_conf:
+            sv_conf.write(textwrap.dedent("""\
+            [inet_http_server]
+            port = 127.0.0.1:17799
+            username = supervisor
+            password = admin
+            """))
+
+        return deployment_dir
+
+    def test_to_influxdb_line_protocol(self):
+        metrics = {
+            'instance1': {
+                'cache':
+                    {'size': 10,
+                     'max_size': 20},
+                'memory':
+                    {'pss': 5,
+                     'rss': 15},
+            },
+            'instance2': {
+                'cache':
+                    {'size': 11,
+                     'max_size': 22},
+                'memory':
+                    {'pss': 7,
+                     'rss': 42},
+            },
+        }
+
+        expected = textwrap.dedent("""\
+        deployments,deployment=01-foo.example.org,process=instance1 cache.max_size=20,cache.size=10,memory.pss=5,memory.rss=15
+        deployments,deployment=01-foo.example.org,process=instance2 cache.max_size=22,cache.size=11,memory.pss=7,memory.rss=42
+        """)  # noqa
+
+        influx_lines = to_influxdb_line_protocol(metrics, '01-foo.example.org')
+        self.assertEqual(expected, influx_lines)
+
+    def test_get_supervisor_conf(self):
+        deployment_dir = self._create_fake_deployment_directory()
+
+        conf = get_supervisor_conf(deployment_dir)
+        bind_addr = conf.get('inet_http_server', 'port')
+        self.assertEqual('127.0.0.1:17799', bind_addr)
+
+    def test_get_supervisor_port(self):
+        deployment_dir = self._create_fake_deployment_directory()
+
+        port = get_supervisor_port(deployment_dir)
+        self.assertEqual(17799, port)
+
+    def test_get_base_port(self):
+        deployment_dir = self._create_fake_deployment_directory()
+
+        port = get_base_port(deployment_dir)
+        self.assertEqual(17700, port)
+
+    def test_find_instances(self):
+        deployment_dir = self._create_fake_deployment_directory()
+
+        instances = find_instances(deployment_dir)
+        self.assertEqual([
+            {'name': u'instance0', 'number': 0, 'port': 17700},
+            {'name': u'instance1', 'number': 1, 'port': 17701},
+            {'name': u'instance2', 'number': 2, 'port': 17702},
+            {'name': u'instance3', 'number': 3, 'port': 17703},
+            {'name': u'instance4', 'number': 4, 'port': 17704}],
+            instances)

--- a/ftw/monitor/tests/test_utils.py
+++ b/ftw/monitor/tests/test_utils.py
@@ -1,0 +1,36 @@
+from ftw.monitor.utils import netcat
+from unittest import TestCase
+import SocketServer
+import threading
+
+
+class TCPEchoHandler(SocketServer.BaseRequestHandler):
+
+    def handle(self):
+        data = self.request.recv(1024)
+        response = "Received: %s" % data
+        self.request.sendall(response)
+
+
+class TestNetcatHelper(TestCase):
+
+    def setUp(self):
+        self.server = SocketServer.ThreadingTCPServer(
+            ('localhost', 0), TCPEchoHandler)
+        self.ip, self.port = self.server.server_address
+
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+        self.addCleanup(self.stop_server)
+
+    def stop_server(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.server_thread.join(timeout=5)
+
+    def test_returns_reply(self):
+        msg = 'hello'
+        reply = netcat(self.ip, self.port, msg)
+        self.assertEqual('Received: %s' % msg, reply)

--- a/ftw/monitor/tests/test_utils.py
+++ b/ftw/monitor/tests/test_utils.py
@@ -1,7 +1,9 @@
 from ftw.monitor.utils import netcat
 from unittest import TestCase
+import socket
 import SocketServer
 import threading
+import time
 
 
 class TCPEchoHandler(SocketServer.BaseRequestHandler):
@@ -9,6 +11,8 @@ class TCPEchoHandler(SocketServer.BaseRequestHandler):
     def handle(self):
         data = self.request.recv(1024)
         response = "Received: %s" % data
+        if data == 'DELAY':
+            time.sleep(1)
         self.request.sendall(response)
 
 
@@ -34,3 +38,8 @@ class TestNetcatHelper(TestCase):
         msg = 'hello'
         reply = netcat(self.ip, self.port, msg)
         self.assertEqual('Received: %s' % msg, reply)
+
+    def test_accepts_timeout(self):
+        msg = 'DELAY'
+        with self.assertRaises(socket.timeout):
+            netcat(self.ip, self.port, msg, timeout=0.5)

--- a/ftw/monitor/utils.py
+++ b/ftw/monitor/utils.py
@@ -1,0 +1,15 @@
+import socket
+
+
+def netcat(hostname, port, content):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((hostname, port))
+    s.sendall(content)
+    reply = ''
+    while 1:
+        data = s.recv(1024)
+        if data == '':
+            break
+        reply += data
+    s.close()
+    return reply

--- a/ftw/monitor/utils.py
+++ b/ftw/monitor/utils.py
@@ -1,8 +1,10 @@
 import socket
 
 
-def netcat(hostname, port, content):
+def netcat(hostname, port, content, timeout=None):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if timeout is not None:
+        s.settimeout(timeout)
     s.connect((hostname, port))
     s.sendall(content)
     reply = ''

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.1.1.dev0'
+version = '1.2.0.dev0'
 
 tests_require = [
     'ftw.testing',
@@ -67,5 +67,8 @@ setup(
 
     [plone.recipe.zope2instance.ctl]
     monitor = ftw.monitor.command:monitor
+
+    [console_scripts]
+    dump-perf-metrics = ftw.monitor.command:dump_perf_metrics
     """,
 )


### PR DESCRIPTION
This adds a script `bin/dump-perf-metrics` that dumps performance metrics for all (reachable) Zope instances in [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/) format.

Output will look something like this:

```
deployments,deployment=01-foo.example.org,process=instance1 cache.max_size=20,cache.size=10,memory.pss=5,memory.rss=15
deployments,deployment=01-foo.example.org,process=instance2 cache.max_size=22,cache.size=11,memory.pss=7,memory.rss=42
```

*(Made up example, simplified for readability)*

----

The output includes all fields from the existing `perf_metrics` command, the measurement name `deployments`, plus two tags:

- `deployment` - name of the deployment directory
- `process` - instance name in case of Z2 instances, or in the future possibly `solr` or `zeo`.

Fields are nested in groups using `.` as the delimiter - which I tested works fine with InfluxDB and Grafana. 

The tags allow for GROUP BY queries and templating in Grafana, like
`SHOW TAG VALUES WITH KEY = "deployment"` (template expression).

Ingestion via Telegraf has been tested with an exec plugin configuration like this:

```
[[inputs.exec]]
  commands = [
    "/path/to/deployment/bin/dump-perf-metrics"
  ]

  timeout = "5s"
  interval = "10s"
  data_format = "influx"
  ```

*(Tested **indirectly** - loop that continiously dumps stats to a file on the local filesystem, having that file mounted into the telegraf docker container, and have the exec command actually just `cat` that file inside the container).*

Jira: https://4teamwork.atlassian.net/browse/GEVER-594